### PR TITLE
Focus hosted sign up page

### DIFF
--- a/multi_tenancy/templates/signup.html
+++ b/multi_tenancy/templates/signup.html
@@ -1,10 +1,9 @@
 {% extends 'layout.html' %}
 
 {% block content %}
-    <form class="form-signin" method="post" action="/signup" style="max-width: 1024px">
+    <form class="form-signin" method="post" action="/signup" style="max-width: 500px">
         {% csrf_token %}
-        <div class="row">
-            <div class='col-6' style="border-right: 1px solid rgba(0, 0, 0, 0.1);padding-right: 30px">
+            <div class='col-3' style="border-right: 1px solid rgba(0, 0, 0, 0.1);padding-right: 30px"></div>
                 <h1 class="h3 mb-3 font-weight-normal">Create a PostHog.com account</h1>
                 All the PostHog goodies, hosted by us. 
                 {% if error %}
@@ -31,13 +30,5 @@
                 <p>Already have an account? <a href='/login'>Log in here.</a></p>
                 <button class="btn btn-lg btn-primary btn-block" type="submit">Start free trial</button>
             </div>
-            <div class='col-6' style="padding-left: 30px">
-                <h1 class="h3 mb-3 font-weight-normal">Host it yourself</h1>
-                You can host your own instance of PostHog on your own infrastructure.<br /><br />
-                <a href="https://heroku.com/deploy?template=https://github.com/posthog/posthog"><img alt="Deploy" src="https://www.herokucdn.com/deploy/button.svg" style="max-width:100%;"></a>
-                <br /><br />
-                Or <a href="https://github.com/posthog/posthog">click here for Docker or building from source.</a>
-            </div>
-        </div>
     </form>
 {% endblock %}

--- a/multi_tenancy/templates/signup.html
+++ b/multi_tenancy/templates/signup.html
@@ -1,11 +1,22 @@
 {% extends 'layout.html' %}
 
 {% block content %}
-    <form class="form-signin" method="post" action="/signup" style="max-width: 500px">
+    <form class="form-signin" method="post" action="/signup" style="max-width: 1024px">
         {% csrf_token %}
-            <div class='col-3' style="border-right: 1px solid rgba(0, 0, 0, 0.1);padding-right: 30px"></div>
-                <h1 class="h3 mb-3 font-weight-normal">Create a PostHog.com account</h1>
-                All the PostHog goodies, hosted by us. 
+        <div class="row">
+            <div class='col-6' style="padding-left: 30px; padding-right: 60px;">
+                <h1 class="h3 mb-3 font-weight-normal">Get Started for Free</h1>
+                <h4>You will have access to all features immediately such as:</h4>
+                <ul class="list-group">
+                    <li class="list-group-item">Trend Visualizations</li>
+                    <li class="list-group-item">User Funnels</li>
+                    <li class="list-group-item">Cohort Analysis</li>
+                </ul>
+                <br></br>
+                <p>By signing up, you will be started on the the trial growth plan which provides you 500,000 events/month, 12 months of data history, and community support. </p>
+            </div>
+            <div class='col-6' style="border-left: 1px solid rgba(0, 0, 0, 0.1);padding-right: 30px">
+                <h1 class="h3 mb-3 font-weight-normal">Create account</h1>
                 {% if error %}
                 <p class="text-danger">That account already exists. <a href='/login'>Try logging in?</a>.</p>
                 {% endif %}
@@ -28,7 +39,8 @@
                     </div>
                 </div>
                 <p>Already have an account? <a href='/login'>Log in here.</a></p>
-                <button class="btn btn-lg btn-primary btn-block" type="submit">Start free trial</button>
+                <button class="btn btn-lg btn-primary btn-block" type="submit">Get Started</button>
             </div>
+        </div>
     </form>
 {% endblock %}


### PR DESCRIPTION
Made a small tweak to the hosted page to keep the user intention focused. Added some copy to encourage users to go through with signup because the "trial" still provides you all functionality. 

I didn't do much to beautify the page because I think that will become part of the [overhaul](https://github.com/PostHog/posthog.com/issues/129)

<img width="1160" alt="Screen Shot 2020-06-17 at 3 26 37 PM" src="https://user-images.githubusercontent.com/13127476/84941301-2f723280-b0af-11ea-8145-4464af63be48.png">
