### PR TITLE
change template order

### DIFF
--- a/multi_tenancy_settings.py
+++ b/multi_tenancy_settings.py
@@ -16,7 +16,7 @@ if (
     and isinstance(TEMPLATES[0]["DIRS"], list)
 ):
 
-    TEMPLATES[0]["DIRS"].append("multi_tenancy/templates")
+    TEMPLATES[0]["DIRS"].insert(0, "multi_tenancy/templates")
 
 
 # Stripe settings


### PR DESCRIPTION
Previously we were using the oss "login.html" page which meant there was no way of getting from the login page to the signup page.