### PR TITLE
Update Cloud for posthog#1562 going live

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -21,10 +21,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Python 3.x
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: "3.x"
+          python-version: "3.8"
 
       - name: Fetch posthog main repo
         run: bin/pull_main

--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -40,7 +40,7 @@ class TestOrganizationBilling(TransactionBaseTest):
             first_name="X",
             email=f"user{random.randint(100, 999)}@posthog.com",
             password=self.TESTS_PASSWORD,
-            team_fields={"api_token": "token123"},
+            team_fields={"api_token": "token789"},
         )
 
     def create_plan(self, **kwargs):

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -54,7 +54,8 @@ class TestTeamSignup(TransactionBaseTest):
         self.assertEqual(user.email_opt_in, False)
 
         # Assert that the team was properly created
-        self.assertEqual(team.name, "Hedgehogs United, LLC")
+        self.assertEqual(organization.name, "Hedgehogs United, LLC")
+        self.assertEqual(team.name, "Default Project")
 
         # Assert that the sign up event & identify calls were sent to PostHog analytics
         mock_capture.assert_called_once_with(

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -60,7 +60,7 @@ class TestTeamSignup(TransactionBaseTest):
         mock_capture.assert_called_once_with(
             user.distinct_id,
             "user signed up",
-            properties={"is_first_user": False, "is_team_first_user": True},
+            properties={"is_first_user": False, "is_organization_first_user": True},
         )
 
         mock_identify.assert_called_once_with(
@@ -114,7 +114,7 @@ class TestTeamSignup(TransactionBaseTest):
         mock_capture.assert_called_once_with(
             user.distinct_id,
             "user signed up",
-            properties={"is_first_user": False, "is_team_first_user": True},
+            properties={"is_first_user": False, "is_organization_first_user": True},
         )
 
         # Assert that the user is logged in
@@ -169,7 +169,7 @@ class TestTeamSignup(TransactionBaseTest):
         mock_capture.assert_called_once_with(
             user.distinct_id,
             "user signed up",
-            properties={"is_first_user": False, "is_team_first_user": True},
+            properties={"is_first_user": False, "is_organization_first_user": True},
         )
 
     @patch("posthoganalytics.capture")
@@ -200,7 +200,7 @@ class TestTeamSignup(TransactionBaseTest):
         mock_capture.assert_called_once_with(
             user.distinct_id,
             "user signed up",
-            properties={"is_first_user": False, "is_team_first_user": True},
+            properties={"is_first_user": False, "is_organization_first_user": True},
         )
 
         # Check that the process_organization_signup_messaging task was fired
@@ -247,7 +247,7 @@ class TestTeamSignup(TransactionBaseTest):
         mock_capture.assert_called_once_with(
             user.distinct_id,
             "user signed up",
-            properties={"is_first_user": False, "is_team_first_user": True},
+            properties={"is_first_user": False, "is_organization_first_user": True},
         )
 
         mock_identify.assert_called_once_with(


### PR DESCRIPTION
This makes PostHog Cloud compatible with PostHog/posthog#1562.
NB: CI will be failing here, because it runs against main repo `master`, while I'm adjusting this branch against `teams`.