### PR TITLE
Switch to the official Heroku Python buildpack

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,25 +11,17 @@
       "env": {
         "DEBUG": true
       },
-      "buildpacks": [
-        {"url": "heroku/nodejs"},
-        {"url": "https://github.com/timgl/heroku-buildpack-python.git"}
-      ]
+      "buildpacks": [{ "url": "heroku/nodejs" }, { "url": "heroku/python" }]
     },
     "test": {
       "addons": ["heroku-postgresql:in-dyno"],
       "scripts": {
         "test": "python manage.py test --keepdb -v 2"
       },
-      "buildpacks": [
-        {"url": "https://github.com/timgl/heroku-buildpack-python.git"}
-      ]
+      "buildpacks": [{ "url": "heroku/python" }]
     }
   },
-  "buildpacks": [
-        {"url": "heroku/nodejs"},
-        {"url": "https://github.com/timgl/heroku-buildpack-python.git"}
-  ],
+  "buildpacks": [{ "url": "heroku/nodejs" }, { "url": "heroku/python" }],
   "addons": [
       "heroku-postgresql"
   ],


### PR DESCRIPTION
Previously `app.json` was configured to use a fork of the Heroku Python buildpack, rather than the official buildpack. Using the official buildpack is recommended, since:
1. The fork is using the old S3 bucket, so doesn't have newer versions of Python/Heroku-20 support
2. The official buildpacks have strict access controls and auditing, compared to third party buildpacks
3. The Heroku build workers pre-cache the official buildpacks, saving the need to Git clone the repo

This is the `posthog-production` equivalent of PostHog/posthog/pull/2151.