### PR TITLE
Improvements to billing logic

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -49,7 +49,7 @@ jobs:
           cd deploy
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install freezegun
+          python -m pip install freezegun fakeredis
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Run posthog tests
@@ -122,7 +122,7 @@ jobs:
           cd deploy
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
-          python -m pip install freezegun
+          python -m pip install freezegun fakeredis
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Check migrations

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ env
 .vscode/*
 .idea/
 .mypy_cache/
+.python-version


### PR DESCRIPTION
- Adds logic for this repo to handle billing logic that's applicable only to cloud (i.e. previously the `ee` app on the main repo would decide which features each plan had enabled, with this PR, the logic can go on this repo).
- Will validate that plans are active before enabling paid features.