### PR TITLE
Add `is_metered_billing` attribute to plan serializer

### DIFF
--- a/multi_tenancy/serializers.py
+++ b/multi_tenancy/serializers.py
@@ -59,6 +59,7 @@ class PlanSerializer(ReadOnlySerializer):
             "allowance",
             "image_url",
             "self_serve",
+            "is_metered_billing",
         ]
 
     def get_allowance(self, obj: Plan) -> Optional[Dict]:

--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -486,6 +486,7 @@ class TestAPIOrganizationBilling(TransactionBaseTest, PlanTestMixin):
                 "allowance": {"value": 8500000, "formatted": "8.5M"},
                 "image_url": "http://test.posthog.com/image.png",
                 "self_serve": True,
+                "is_metered_billing": False,
             },
         )
 
@@ -704,6 +705,7 @@ class PlanTestCase(APIBaseTest, PlanTestMixin):
                     "allowance",
                     "image_url",
                     "self_serve",
+                    "is_metered_billing",
                 ],
             )
 
@@ -738,6 +740,7 @@ class PlanTestCase(APIBaseTest, PlanTestMixin):
                     "allowance",
                     "image_url",
                     "self_serve",
+                    "is_metered_billing",
                 ],
             )
             self.assertEqual(obj.self_serve, True)

--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -220,6 +220,7 @@ class TestAPIOrganizationBilling(TransactionBaseTest, PlanTestMixin):
                 "allowance": {"value": 50000, "formatted": "50K"},
                 "image_url": "",
                 "self_serve": False,
+                "is_metered_billing": False,
             },
         )
 
@@ -296,6 +297,7 @@ class TestAPIOrganizationBilling(TransactionBaseTest, PlanTestMixin):
                 "allowance": None,
                 "image_url": "",
                 "self_serve": False,
+                "is_metered_billing": False,
             },
         )
 
@@ -371,6 +373,7 @@ class TestAPIOrganizationBilling(TransactionBaseTest, PlanTestMixin):
                 "allowance": None,
                 "image_url": "",
                 "self_serve": False,
+                "is_metered_billing": True,
             },
         )
 


### PR DESCRIPTION
Adds the referenced attribute to enable customization for metered-based billing plans in the front-end.