### PR TITLE
Fixes tests for 2937 (posthog) & add Reply-To header in emails

### DIFF
--- a/messaging/mail.py
+++ b/messaging/mail.py
@@ -1,10 +1,11 @@
+import re
 from typing import ClassVar, Dict, Optional
 
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 
-import re
 from .models import UserMessagingRecord
+
 
 class Mail:
     FROM_ADDRESS: ClassVar[str] = "PostHog Team <hey@posthog.com>"
@@ -75,6 +76,7 @@ class Mail:
             from_email=cls.FROM_ADDRESS,
             to=[f"{pattern.sub('', name)} <{email_address}>"],
             headers=cls.EMAIL_HEADERS,
+            reply_to=settings.EMAIL_REPLY_TO,
         )
         email_message.attach_alternative(html_content, "text/html")
         email_message.send()

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -66,11 +66,7 @@ class TestTeamSignup(TransactionBaseTest):
 
         mock_identify.assert_called_once_with(
             user.distinct_id,
-            properties={
-                "email": "hedgehog@posthog.com",
-                "realm": "cloud",
-                "ee_available": False,
-            },
+            properties={"is_first_user": False, "is_organization_first_user": True},
         )
 
         # Assert that the user is logged in
@@ -163,7 +159,8 @@ class TestTeamSignup(TransactionBaseTest):
 
         # Check that the process_organization_signup_messaging task was fired
         mock_messaging.assert_called_once_with(
-            user_id=user.id, organization_id=str(organization.id),
+            user_id=user.id,
+            organization_id=str(organization.id),
         )
 
         # Check that we send the sign up event to PostHog analytics
@@ -206,14 +203,16 @@ class TestTeamSignup(TransactionBaseTest):
 
         # Check that the process_organization_signup_messaging task was fired
         mock_messaging.assert_called_once_with(
-            user_id=user.pk, organization_id=str(organization.id),
+            user_id=user.pk,
+            organization_id=str(organization.id),
         )
 
     @patch("messaging.tasks.process_organization_signup_messaging.delay")
-    @patch("posthoganalytics.identify")
     @patch("posthoganalytics.capture")
     def test_sign_up_multiple_teams_multi_tenancy(
-        self, mock_capture, mock_identify, mock_messaging,
+        self,
+        mock_capture,
+        mock_messaging,
     ):
 
         # Create a user first to make sure additional users can be created
@@ -251,15 +250,6 @@ class TestTeamSignup(TransactionBaseTest):
             properties={"is_first_user": False, "is_organization_first_user": True},
         )
 
-        mock_identify.assert_called_once_with(
-            user.distinct_id,
-            properties={
-                "email": "multi@posthog.com",
-                "realm": "cloud",
-                "ee_available": True,
-            },
-        )
-
         # Assert that the user is logged in
         response = self.client.get("/api/user/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -270,5 +260,6 @@ class TestTeamSignup(TransactionBaseTest):
 
         # Check that the process_organization_signup_messaging task was fired
         mock_messaging.assert_called_once_with(
-            user_id=user.pk, organization_id=str(user.organization.id),
+            user_id=user.pk,
+            organization_id=str(user.organization.id),
         )

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -66,7 +66,7 @@ class TestTeamSignup(TransactionBaseTest):
 
         mock_identify.assert_called_once_with(
             user.distinct_id,
-            properties={"is_first_user": False, "is_organization_first_user": True},
+            {"is_first_user": False, "is_organization_first_user": True},
         )
 
         # Assert that the user is logged in


### PR DESCRIPTION
- Fixes cloud tests from https://github.com/PostHog/posthog/pull/2937.
- Adds `Reply-To` header to emails (per https://github.com/PostHog/posthog/pull/2846).﻿
