### PR TITLE
Install dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "yarn": "1.x"
   },
   "scripts": {
-    "heroku-postbuild": "bin/pull_main && cd deploy && yarn install --frozen-lockfile && yarn build && cp requirements.txt ../",
+    "heroku-postbuild": "bin/pull_main && cd deploy && yarn install --production=false --frozen-lockfile && yarn build && cp requirements.txt ../",
     "build": "cd deploy && yarn build"
   },
   "cacheDirectories": [


### PR DESCRIPTION
Running `yarn build` in `deploy` fails with:

```
       $ echo "Building Webpack" && NODE_ENV=production webpack --config webpack.config.js && cp -a frontend/public/* frontend/dist/ && npm run copy-scripts
/bin/sh: 1:        Building Webpack
webpack: not found
```

Probably NODE_ENV is set to `production` somewhere and thus it doesn't install dev deps. This [should fix it](https://classic.yarnpkg.com/en/docs/cli/install/#toc-yarn-install-production-true-false).