### PR TITLE
Signup validation: validate email does not exist

### DIFF
--- a/multi_tenancy/serializers.py
+++ b/multi_tenancy/serializers.py
@@ -29,6 +29,11 @@ class MultiTenancyOrgSignupSerializer(OrganizationSignupSerializer):
         except Plan.DoesNotExist:
             return None
 
+    def validate_email(self, value):
+        if User.objects.filter(email__iexact=value).exists():
+            raise serializers.ValidationError("Email already in use.", code="unique")
+        return value
+
     def create(self, validated_data: Dict) -> User:
         plan = validated_data.pop("plan", None)
         user = super().create(validated_data)

--- a/multi_tenancy/tests/test_signup.py
+++ b/multi_tenancy/tests/test_signup.py
@@ -83,6 +83,32 @@ class TestTeamSignup(TransactionBaseTest):
             user_id=user.id, organization_id=str(organization.id)
         )
 
+
+    @patch("messaging.tasks.process_organization_signup_messaging.delay")
+    @patch("posthoganalytics.identify")
+    @patch("posthoganalytics.capture")
+    def test_api_sign_up_existing_email(self, mock_capture, mock_identify, mock_messaging):
+        response = self.client.post(
+            "/api/signup/",
+            {
+                "first_name": "John",
+                "email": "firstuser@posthog.com",
+                "password": "notsecure",
+                "company_name": "Hedgehogs United, LLC",
+                "email_opt_in": False,
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {
+                "type": "validation_error",
+                "code": "unique",
+                "detail": "Email already in use.",
+                "attr": "email",
+            },
+        )
+
     @patch("posthoganalytics.capture")
     @patch("messaging.tasks.process_organization_signup_messaging.delay")
     def test_default_user_sign_up(self, mock_messaging, mock_capture):


### PR DESCRIPTION
Currently users would see no error since we removed the generic error
toast.

Sentry error: https://sentry.io/organizations/posthog/issues/1892659475/?project=1899813&query=is%3Aunassigned+is%3Aunresolved
