### PR TITLE
Remove billing server-side formatting

### DIFF
--- a/multi_tenancy/models.py
+++ b/multi_tenancy/models.py
@@ -55,19 +55,6 @@ class Plan(models.Model):
     def __str__(self) -> str:
         return self.name
 
-    @property
-    def allowance(self) -> Optional[Dict[str, Union[str, int]]]:
-        """
-        Formatted event allowance.
-        """
-        if not self.event_allowance:
-            return None
-
-        return {
-            "value": self.event_allowance,
-            "formatted": compact_number(self.event_allowance),
-        }
-
 
 class OrganizationBilling(models.Model):
     """An extension to Organization for handling PostHog Cloud billing."""

--- a/multi_tenancy/models.py
+++ b/multi_tenancy/models.py
@@ -115,23 +115,14 @@ class OrganizationBilling(models.Model):
         return self.plan.price_id if self.plan else ""
 
     @property
-    def event_allocation(self) -> Optional[Dict[str, Union[str, int]]]:
+    def event_allocation(self) -> Optional[int]:
         """
         Returns the event allocation applicable to the organization.
         """
-        if not self.plan or not self.is_billing_active:
+        if not self.is_billing_active:
             # No active billing plan, default to event allocation for when no billing plan is active
-            no_plan_event_allocation = settings.BILLING_NO_PLAN_EVENT_ALLOCATION
-
-            if no_plan_event_allocation is None:
-                return None
-
-            return {
-                "value": no_plan_event_allocation,
-                "formatted": compact_number(no_plan_event_allocation),
-            }
-
-        return self.plan.allowance
+            return settings.BILLING_NO_PLAN_EVENT_ALLOCATION
+        return self.plan.event_allowance
 
     @property
     def available_features(self) -> List[str]:

--- a/multi_tenancy/serializers.py
+++ b/multi_tenancy/serializers.py
@@ -55,7 +55,7 @@ class PlanSerializer(ReadOnlySerializer):
             "key",
             "name",
             "custom_setup_billing_message",
-            "allowance",
+            "event_allowance",
             "image_url",
             "self_serve",
             "is_metered_billing",

--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -283,7 +283,7 @@ class TestAPIOrganizationBilling(TransactionBaseTest, PlanTestMixin):
                 "key": plan.key,
                 "name": plan.name,
                 "custom_setup_billing_message": "Sign up now!",
-                "allowance": {"value": 50000, "formatted": "50K"},
+                "event_allowance": 50000,
                 "image_url": "",
                 "self_serve": False,
                 "is_metered_billing": False,
@@ -349,7 +349,7 @@ class TestAPIOrganizationBilling(TransactionBaseTest, PlanTestMixin):
                 "key": "startup",
                 "name": plan.name,
                 "custom_setup_billing_message": "",
-                "allowance": None,
+                "event_allowance": None,
                 "image_url": "",
                 "self_serve": False,
                 "is_metered_billing": False,
@@ -415,7 +415,7 @@ class TestAPIOrganizationBilling(TransactionBaseTest, PlanTestMixin):
                 "key": "usage1",
                 "name": plan.name,
                 "custom_setup_billing_message": "",
-                "allowance": None,
+                "event_allowance": None,
                 "image_url": "",
                 "self_serve": False,
                 "is_metered_billing": True,
@@ -520,7 +520,7 @@ class TestAPIOrganizationBilling(TransactionBaseTest, PlanTestMixin):
                 "key": plan.key,
                 "name": plan.name,
                 "custom_setup_billing_message": "",
-                "allowance": {"value": 8500000, "formatted": "8.5M"},
+                "event_allowance": 8500000,
                 "image_url": "http://test.posthog.com/image.png",
                 "self_serve": True,
                 "is_metered_billing": False,
@@ -739,7 +739,7 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
                     "key",
                     "name",
                     "custom_setup_billing_message",
-                    "allowance",
+                    "event_allowance",
                     "image_url",
                     "self_serve",
                     "is_metered_billing",
@@ -747,10 +747,7 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
                 ],
             )
 
-            if obj.event_allowance:
-                self.assertEqual(
-                    item["allowance"], {"value": 49334, "formatted": "49.3K"},
-                )
+            self.assertEqual(item["event_allowance"], 49334)
 
             retrieve_response = self.client.get(f"/plans/{obj.key}")
             self.assertEqual(retrieve_response.status_code, status.HTTP_200_OK)
@@ -774,7 +771,7 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
                     "key",
                     "name",
                     "custom_setup_billing_message",
-                    "allowance",
+                    "event_allowance",
                     "image_url",
                     "self_serve",
                     "is_metered_billing",

--- a/multi_tenancy/views.py
+++ b/multi_tenancy/views.py
@@ -63,7 +63,7 @@ def user_with_billing(request: HttpRequest):
     response = user(request)
 
     if response.status_code == 200 and request.user.organization:
-        instance, _created = OrganizationBilling.objects.get_or_create(organization=request.user.organization,)
+        instance, _ = OrganizationBilling.objects.get_or_create(organization=request.user.organization,)
 
         output = json.loads(response.content)
 
@@ -80,11 +80,7 @@ def user_with_billing(request: HttpRequest):
         except Exception as e:
             capture_exception(e)
 
-        if event_usage is not None:
-            output["billing"]["current_usage"] = {
-                "value": event_usage,
-                "formatted": compact_number(event_usage),
-            }
+        output["billing"]["current_usage"] = event_usage
 
         if instance.plan:
             plan_serializer = PlanSerializer()


### PR DESCRIPTION
Subsequent PR to https://github.com/PostHog/posthog/pull/3360.
- Remove server-side formatting of billing numbers.
- Remove legacy `allowance` property of `Plan` model.
