### PR TITLE
Move plans endpoints under /api

### DIFF
--- a/multi_tenancy/tests/test_billing.py
+++ b/multi_tenancy/tests/test_billing.py
@@ -724,7 +724,7 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
         self.create_plan(event_allowance=49334, self_serve=True)
 
     def test_listing_and_retrieving_plans(self):
-        response = self.client.get("/plans")
+        response = self.client.get("/api/plans")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data["count"], Plan.objects.exclude(is_active=False).count(),
@@ -752,14 +752,14 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
                     item["allowance"], {"value": 49334, "formatted": "49.3K"},
                 )
 
-            retrieve_response = self.client.get(f"/plans/{obj.key}")
+            retrieve_response = self.client.get(f"/api/plans/{obj.key}")
             self.assertEqual(retrieve_response.status_code, status.HTTP_200_OK)
             self.assertEqual(
                 retrieve_response.data, item,
             )  # Retrieve response is equal to list response
 
     def test_list_self_serve_plans(self):
-        response = self.client.get("/plans?self_serve=1")
+        response = self.client.get("/api/plans?self_serve=1")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data["count"], Plan.objects.exclude(is_active=False).exclude(self_serve=False).count(),
@@ -785,7 +785,7 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
 
     def test_inactive_plans_cannot_be_retrieved(self):
         plan = self.create_plan(is_active=False)
-        response = self.client.get(f"/plans/{plan.key}")
+        response = self.client.get(f"/api/plans/{plan.key}")
         self.assertEqual(
             response.json(), {"attr": None, "code": "not_found", "detail": "Not found.", "type": "invalid_request",},
         )
@@ -801,7 +801,7 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
         expected = f.read()
         f.close()
 
-        response = self.client.get("/plans/standard/template/")
+        response = self.client.get("/api/plans/standard/template/")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.content.decode(), expected)
 
@@ -811,18 +811,18 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
 
         # Plan has no template
         self.create_plan(key="new_plan")
-        response = self.client.get("/plans/new_plan/template/")
+        response = self.client.get("/api/plans/new_plan/template/")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content.decode(), "")
 
         # Plan is not active
         self.create_plan(key="starter", is_active=False)
-        response = self.client.get("/plans/new_plan/template/")
+        response = self.client.get("/api/plans/new_plan/template/")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content.decode(), "")
 
         # Plan does not exist
-        response = self.client.get("/plans/im_inavlid/template/")
+        response = self.client.get("/api/plans/im_inavlid/template/")
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertEqual(response.content.decode(), "")
 
@@ -830,13 +830,13 @@ class PlanAPITestCase(APIBaseTest, PlanTestMixin):
         plan = self.create_plan()
 
         # PUT UPDATE
-        response = self.client.put(f"/plans/{plan.key}", {"price_id": "new_pricing"})
+        response = self.client.put(f"/api/plans/{plan.key}", {"price_id": "new_pricing"})
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         plan.refresh_from_db()
         self.assertNotEqual(plan.price_id, "new_pricing")
 
         # PATCH UPDATE
-        response = self.client.patch(f"/plans/{plan.key}", {"price_id": "new_pricing"})
+        response = self.client.patch(f"/api/plans/{plan.key}", {"price_id": "new_pricing"})
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
         plan.refresh_from_db()
         self.assertNotEqual(plan.price_id, "new_pricing")

--- a/multi_tenancy/urls.py
+++ b/multi_tenancy/urls.py
@@ -53,7 +53,7 @@ urlpatterns += [
     opt_slash_path("billing/stripe_webhook", stripe_webhook, name="billing_stripe_webhook"),  # Stripe Webhook
     opt_slash_path("billing/subscribe", BillingSubscribeViewset.as_view({"post": "create"}), name="billing_subscribe"),
     opt_slash_path("api/plans", PlanViewset.as_view({"get": "list"}), name="billing_plans"),
-    path("plans/<str:key>/template/", plan_template, name="billing_plan_template"),
-    path("plans/<str:key>", PlanViewset.as_view({"get": "retrieve"}), name="billing_plan"),
+    path("api/plans/<str:key>/template/", plan_template, name="billing_plan_template"),
+    path("api/plans/<str:key>", PlanViewset.as_view({"get": "retrieve"}), name="billing_plan"),
     re_path(r"^.*", decorators.login_required(home)),  # Should always be at the very last position
 ]

--- a/multi_tenancy/urls.py
+++ b/multi_tenancy/urls.py
@@ -27,6 +27,9 @@ urlpatterns: List = [
     opt_slash_path(
         "api/signup", MultiTenancyOrgSignupViewset.as_view(),
     ),  # Override to support setting a billing plan on signup
+    opt_slash_path("api/plans", PlanViewset.as_view({"get": "list"}), name="billing_plans"),
+    path("api/plans/<str:key>/template/", plan_template, name="billing_plan_template"),
+    path("api/plans/<str:key>", PlanViewset.as_view({"get": "retrieve"}), name="billing_plan"),
 ]
 
 # Include `posthog` default routes, except the home route (to give precendence to billing routes)
@@ -52,8 +55,5 @@ urlpatterns += [
     ),  # Page with success message after setting up billing for hosted plans
     opt_slash_path("billing/stripe_webhook", stripe_webhook, name="billing_stripe_webhook"),  # Stripe Webhook
     opt_slash_path("billing/subscribe", BillingSubscribeViewset.as_view({"post": "create"}), name="billing_subscribe"),
-    opt_slash_path("api/plans", PlanViewset.as_view({"get": "list"}), name="billing_plans"),
-    path("api/plans/<str:key>/template/", plan_template, name="billing_plan_template"),
-    path("api/plans/<str:key>", PlanViewset.as_view({"get": "retrieve"}), name="billing_plan"),
     re_path(r"^.*", decorators.login_required(home)),  # Should always be at the very last position
 ]

--- a/multi_tenancy/urls.py
+++ b/multi_tenancy/urls.py
@@ -5,10 +5,19 @@ from django.urls import path, re_path
 from posthog.urls import home, opt_slash_path
 from posthog.urls import urlpatterns as posthog_urls
 
-from .views import (BillingSubscribeViewset, MultiTenancyOrgSignupViewset,
-                    PlanViewset, billing_failed_view, billing_hosted_view,
-                    billing_welcome_view, plan_template, stripe_billing_portal,
-                    stripe_checkout_view, stripe_webhook, user_with_billing)
+from .views import (
+    BillingSubscribeViewset,
+    MultiTenancyOrgSignupViewset,
+    PlanViewset,
+    billing_failed_view,
+    billing_hosted_view,
+    billing_welcome_view,
+    plan_template,
+    stripe_billing_portal,
+    stripe_checkout_view,
+    stripe_webhook,
+    user_with_billing,
+)
 
 # Include `posthog-production` override routes first
 urlpatterns: List = [
@@ -43,7 +52,7 @@ urlpatterns += [
     ),  # Page with success message after setting up billing for hosted plans
     opt_slash_path("billing/stripe_webhook", stripe_webhook, name="billing_stripe_webhook"),  # Stripe Webhook
     opt_slash_path("billing/subscribe", BillingSubscribeViewset.as_view({"post": "create"}), name="billing_subscribe"),
-    opt_slash_path("plans", PlanViewset.as_view({"get": "list"}), name="billing_plans"),
+    opt_slash_path("api/plans", PlanViewset.as_view({"get": "list"}), name="billing_plans"),
     path("plans/<str:key>/template/", plan_template, name="billing_plan_template"),
     path("plans/<str:key>", PlanViewset.as_view({"get": "retrieve"}), name="billing_plan"),
     re_path(r"^.*", decorators.login_required(home)),  # Should always be at the very last position


### PR DESCRIPTION
- Plans endpoints are now `/api/plans...`. The problem with having them on the root endpoint is that when on self-hosted, if you requested `/plans`, the request would return a 200 (because it would be routed to the front-end), when we actually need a 404 error response (otherwise this leads to a leak in a Kea reducer).
